### PR TITLE
Fixing path to gcc family.

### DIFF
--- a/device/arduino/common.mk
+++ b/device/arduino/common.mk
@@ -1,5 +1,5 @@
 ifeq ($(AVR_HOME),)
-AVR_HOME := /Applications/Arduino.app/Contents/Resources/Java
+	AVR_HOME := /Applications/Arduino.app/Contents/Java
 endif
 
 ifeq ($(CONFIG_AVR_TIMER),)


### PR DESCRIPTION
The latest Arduino IDE seems to have changed the path a bit.